### PR TITLE
Improve performance

### DIFF
--- a/url_regex/url_regex.py
+++ b/url_regex/url_regex.py
@@ -2,6 +2,8 @@ import re
 
 from . import tlds
 
+tlds_sort = "|".join([g for g in sorted(tlds.tlds_list)])
+
 
 class Url:
     def __init__(self, full: str, domain: str, protocol: str = None):
@@ -24,13 +26,12 @@ class UrlRegex:
 
     @property
     def build_regex(self):
-        tlds_sort = "|".join([g for g in sorted(tlds.tlds_list)])
-
         protocol = f"(?:(?:[a-z]+:)?//){'?' if self.strict else ''}"
         auth = "(?:\\S+(?::\\S*)?@)?"
         host = "(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)"
         domain = "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
-        tld = "(?:\\.{})\\.?".format('(?:[a-z\\u00a1-\\uffff]{2,})' if self.strict else f"(?:{tlds_sort})")
+        tld = "(?:\\.{})\\.?".format(
+            '(?:[a-z\\u00a1-\\uffff]{2,})' if self.strict else f"(?:{tlds_sort})")
         port = "(?::\\d{2,5})?"
         path = '(?:[/?#][^\\s,.\"]*)?'
 

--- a/url_regex/url_regex.py
+++ b/url_regex/url_regex.py
@@ -30,8 +30,7 @@ class UrlRegex:
         auth = "(?:\\S+(?::\\S*)?@)?"
         host = "(?:(?:[a-z\\u00a1-\\uffff0-9][-_]*)*[a-z\\u00a1-\\uffff0-9]+)"
         domain = "(?:\\.(?:[a-z\\u00a1-\\uffff0-9]-*)*[a-z\\u00a1-\\uffff0-9]+)*"
-        tld = "(?:\\.{})\\.?".format(
-            '(?:[a-z\\u00a1-\\uffff]{2,})' if self.strict else f"(?:{tlds_sort})")
+        tld = "(?:\\.{})\\.?".format('(?:[a-z\\u00a1-\\uffff]{2,})' if self.strict else f"(?:{tlds_sort})")
         port = "(?::\\d{2,5})?"
         path = '(?:[/?#][^\\s,.\"]*)?'
 


### PR DESCRIPTION
- Move out tlds_sort from the method EltonChou/url_regex@a3060cf20165e8474c1c6e9281f57a410bc8428f

I think this could improve the performance.

Before:
![Before](https://i.gyazo.com/6c63e54eb1de611df7d39407aea6be2d.png)
After:
![After](https://i.gyazo.com/4eac6c9efa84c9e8a211f9842be51d4e.png)

Test code I used.
```py
from url_regex import UrlRegex


def test(strict):
    findlinks = UrlRegex(
        "Hey. watch this video https://www.youtube.com/watch?v=9E2sZhMpOS4&feature=youtu.be", strict=strict)


if __name__ == '__main__':
    import timeit
    print("Is strict: " + str(timeit.timeit("test(True)", setup="from __main__ import test", number=100000)))
    print("Not strict: " + str(timeit.timeit("test(False)", setup="from __main__ import test", number=100000)))
```